### PR TITLE
Add devnet scripts for single validator localnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,34 @@ Libra2 inherits Libra, Diem, and Aptos technologies.
 You can learn more about contributing to the Libra2 project by reading our [Contribution Guide](https://github.com/libra2org/libra2-core/blob/main/CONTRIBUTING.md) and by viewing our [Code of Conduct](https://github.com/aptos-labs/aptos-core/blob/main/CODE_OF_CONDUCT.md).
 
 Libra2 Core is licensed under [Apache 2.0](https://github.com/libra2org/libra2-core/blob/main/LICENSE).
+
+## Local Devnet (Single Validator)
+
+Run a local validator node with a faucet for development:
+
+```bash
+./scripts/devnet-up.sh
+# REST: 127.0.0.1:8080, Faucet: 127.0.0.1:8081
+```
+
+When done, stop the node and clean up data:
+
+```bash
+./scripts/devnet-down.sh
+```
+
+Example CLI usage against the running devnet:
+
+```bash
+# Initialize a local profile pointing at the devnet
+libra2 init --profile local --rest-url http://127.0.0.1:8080 \
+  --faucet-url http://127.0.0.1:8081
+
+# Create a new account and fund it
+libra2 account create --profile local
+ACCOUNT_ADDRESS=$(libra2 account list --profile local | tail -n 1 | awk '{print $2}')
+libra2 account fund-with-faucet --profile local --account "$ACCOUNT_ADDRESS" --amount 100
+
+# Send a transfer
+libra2 account transfer --profile local --to "$ACCOUNT_ADDRESS" --amount 1
+```

--- a/scripts/devnet-down.sh
+++ b/scripts/devnet-down.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+
+DATA_DIR="$HOME/.libra2/localnet"
+
+# Attempt to stop any running localnet instances
+if pgrep -f "libra2.*run-localnet" >/dev/null; then
+  echo "Stopping running localnet"
+  pkill -f "libra2.*run-localnet"
+fi
+
+# Remove localnet data directory
+if [ -d "$DATA_DIR" ]; then
+  echo "Removing localnet data at $DATA_DIR"
+  rm -rf "$DATA_DIR"
+fi

--- a/scripts/devnet-up.sh
+++ b/scripts/devnet-up.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+DATA_DIR="$HOME/.libra2/localnet"
+
+# Remove any previous localnet data
+echo "Cleaning existing localnet data at $DATA_DIR"
+rm -rf "$DATA_DIR"
+
+# Start a new single validator localnet with faucet
+# This uses the Libra2 CLI built from this repository.
+# It will automatically generate keys, genesis, and configuration.
+
+cargo run -p libra2 --release -- node run-localnet --test-dir "$DATA_DIR" --force-restart --with-faucet


### PR DESCRIPTION
## Summary
- add helper scripts to bootstrap and cleanup a local single-validator network with faucet
- document local devnet usage and sample CLI interactions

## Testing
- `bash -n scripts/devnet-up.sh`
- `bash -n scripts/devnet-down.sh`


------
https://chatgpt.com/codex/tasks/task_e_689b7de02d04833280dfc01218e8f6e5