### PR TITLE
Add skeleton txn stream gRPC service

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,8 @@ members = [
     "crates/libra2-id-generator",
     "crates/libra2-infallible",
     "crates/libra2-inspection-service",
+    "crates/libra2-protos-txnstream",
+    "crates/libra2-txnstream-server",
     "crates/libra2-jwk-consensus",
     "crates/libra2-keygen",
     "crates/libra2-ledger",

--- a/crates/libra2-protos-txnstream/Cargo.toml
+++ b/crates/libra2-protos-txnstream/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "libra2-protos-txnstream"
+version = "0.1.0"
+
+# Workspace inherited keys
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+
+[dependencies]
+tonic = { workspace = true }
+prost = { workspace = true }
+
+[build-dependencies]
+tonic-build = { version = "0.12.3", features = ["prost"], default-features = false }
+

--- a/crates/libra2-protos-txnstream/build.rs
+++ b/crates/libra2-protos-txnstream/build.rs
@@ -1,0 +1,6 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tonic_build::configure()
+        .format(false)
+        .compile(&["proto/txnstream/v1/txnstream.proto"], &["proto"])?;
+    Ok(())
+}

--- a/crates/libra2-protos-txnstream/proto/txnstream/v1/txnstream.proto
+++ b/crates/libra2-protos-txnstream/proto/txnstream/v1/txnstream.proto
@@ -1,0 +1,39 @@
+syntax = "proto3";
+
+package txnstream.v1;
+
+message ChainIdResponse {
+  uint32 chain_id = 1;
+}
+
+message ServerInfoResponse {
+  string version = 1;
+  uint64 build_timestamp = 2;
+}
+
+message TransactionsRequest {
+  uint64 start_version = 1;
+  bool include_events = 2;
+  uint32 batch_size = 3;
+  uint32 max_wait_ms = 4;
+  bool exclude_ledger_changes = 5;
+}
+
+message TransactionOutput {
+  uint64 version = 1;
+  bytes txn = 2;
+  repeated bytes events = 3;
+  bytes info = 4;
+}
+
+message TransactionsResponse {
+  repeated TransactionOutput batch = 1;
+}
+
+message Empty {}
+
+service TxnStream {
+  rpc GetChainId(Empty) returns (ChainIdResponse);
+  rpc GetServerInfo(Empty) returns (ServerInfoResponse);
+  rpc StreamTransactions(TransactionsRequest) returns (stream TransactionsResponse);
+}

--- a/crates/libra2-protos-txnstream/src/lib.rs
+++ b/crates/libra2-protos-txnstream/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod txnstream {
+    include!(concat!(env!("OUT_DIR"), "/txnstream.rs"));
+}

--- a/crates/libra2-txnstream-server/Cargo.toml
+++ b/crates/libra2-txnstream-server/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "libra2-txnstream-server"
+version = "0.1.0"
+
+# Workspace inherited keys
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+
+[dependencies]
+libra2-protos-txnstream = { path = "../libra2-protos-txnstream" }
+libra2-config = { workspace = true }
+libra2-telemetry = { workspace = true }
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+tonic = { workspace = true }
+tonic-health = { version = "0.12.3" }
+tokio = { workspace = true }
+tokio-stream = { workspace = true }
+futures = { workspace = true }
+prost = { workspace = true }
+
+[dev-dependencies]
+libra2-protos-txnstream = { path = "../libra2-protos-txnstream" }
+

--- a/crates/libra2-txnstream-server/src/lib.rs
+++ b/crates/libra2-txnstream-server/src/lib.rs
@@ -1,0 +1,81 @@
+use std::net::SocketAddr;
+use std::pin::Pin;
+
+use futures::Stream;
+use tokio_stream::iter;
+use tonic::{transport::Server, Request, Response, Status};
+use tonic_health::server::health_reporter;
+
+use libra2_protos_txnstream::txnstream::txn_stream_server::{TxnStream, TxnStreamServer};
+use libra2_protos_txnstream::txnstream::{
+    ChainIdResponse, Empty, ServerInfoResponse, TransactionsRequest, TransactionsResponse,
+};
+
+/// Basic transaction stream service.
+#[derive(Clone, Debug)]
+pub struct TxnStreamService {
+    chain_id: u32,
+}
+
+#[tonic::async_trait]
+impl TxnStream for TxnStreamService {
+    async fn get_chain_id(
+        &self,
+        _request: Request<Empty>,
+    ) -> Result<Response<ChainIdResponse>, Status> {
+        Ok(Response::new(ChainIdResponse {
+            chain_id: self.chain_id,
+        }))
+    }
+
+    async fn get_server_info(
+        &self,
+        _request: Request<Empty>,
+    ) -> Result<Response<ServerInfoResponse>, Status> {
+        Ok(Response::new(ServerInfoResponse {
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            build_timestamp: 0,
+        }))
+    }
+
+    type StreamTransactionsStream =
+        Pin<Box<dyn Stream<Item = Result<TransactionsResponse, Status>> + Send + 'static>>;
+
+    async fn stream_transactions(
+        &self,
+        _request: Request<TransactionsRequest>,
+    ) -> Result<Response<Self::StreamTransactionsStream>, Status> {
+        let stream = iter(Vec::<Result<TransactionsResponse, Status>>::new());
+        Ok(Response::new(
+            Box::pin(stream) as Self::StreamTransactionsStream
+        ))
+    }
+}
+
+/// Start the gRPC server on the given address.
+pub async fn serve(addr: SocketAddr, chain_id: u32) -> Result<(), anyhow::Error> {
+    let service = TxnStreamService { chain_id };
+    let (mut health_reporter, health_service) = health_reporter();
+    health_reporter
+        .set_serving::<TxnStreamServer<TxnStreamService>>()
+        .await;
+
+    Server::builder()
+        .add_service(health_service)
+        .add_service(TxnStreamServer::new(service))
+        .serve(addr)
+        .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_get_chain_id() {
+        let service = TxnStreamService { chain_id: 7 };
+        let response = service.get_chain_id(Request::new(Empty {})).await.unwrap();
+        assert_eq!(response.into_inner().chain_id, 7);
+    }
+}


### PR DESCRIPTION
## Summary
- add proto definitions for transaction streaming
- introduce placeholder gRPC server implementation
- wire new crates into workspace

## Testing
- `cargo test -p libra2-protos-txnstream --lib` *(fails: failed to download from `https://index.crates.io/config.json`)*
- `cargo test -p libra2-txnstream-server --lib` *(fails: failed to download from `https://index.crates.io/config.json`)*

------
https://chatgpt.com/codex/tasks/task_e_689c54df35248332829e027b087b62ea